### PR TITLE
Taras/1 97 fix

### DIFF
--- a/KernelBench/level1/97_ScaledDotProductAttention.py
+++ b/KernelBench/level1/97_ScaledDotProductAttention.py
@@ -15,9 +15,9 @@ sequence_length = 512
 embedding_dimension = 1024
 
 def get_inputs():
-    Q = torch.rand(batch_size, num_heads, sequence_length, embedding_dimension, dtype=torch.float16)
-    K = torch.rand(batch_size, num_heads, sequence_length, embedding_dimension, dtype=torch.float16)
-    V = torch.rand(batch_size, num_heads, sequence_length, embedding_dimension, dtype=torch.float16)
+    Q = torch.rand(batch_size, num_heads, sequence_length, embedding_dimension)
+    K = torch.rand(batch_size, num_heads, sequence_length, embedding_dimension)
+    V = torch.rand(batch_size, num_heads, sequence_length, embedding_dimension)
     return [Q, K, V]
 
 def get_init_inputs():

--- a/KernelBench/level1/97_ScaledDotProductAttention.py
+++ b/KernelBench/level1/97_ScaledDotProductAttention.py
@@ -15,9 +15,9 @@ sequence_length = 512
 embedding_dimension = 1024
 
 def get_inputs():
-    Q = torch.rand(batch_size, num_heads, sequence_length, embedding_dimension, device='cuda', dtype=torch.float16)
-    K = torch.rand(batch_size, num_heads, sequence_length, embedding_dimension, device='cuda', dtype=torch.float16)
-    V = torch.rand(batch_size, num_heads, sequence_length, embedding_dimension, device='cuda', dtype=torch.float16)
+    Q = torch.rand(batch_size, num_heads, sequence_length, embedding_dimension, dtype=torch.float16)
+    K = torch.rand(batch_size, num_heads, sequence_length, embedding_dimension, dtype=torch.float16)
+    V = torch.rand(batch_size, num_heads, sequence_length, embedding_dimension, dtype=torch.float16)
     return [Q, K, V]
 
 def get_init_inputs():


### PR DESCRIPTION
to support CUDA, MPS and future backend all data movement to corresponding devices should happen implicitly by the caller